### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/buildpush.yaml
+++ b/.github/workflows/buildpush.yaml
@@ -18,7 +18,7 @@ jobs:
       id: extract_tag_name
 
     - name: Build Uproot Image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sslhep/servicex_func_adl_uproot_transformer:${{ steps.extract_tag_name.outputs.imagetag }}
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore